### PR TITLE
Unlimited URL length

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -33,7 +33,7 @@ server() {
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
   TIMEOUT=${REDASH_GUNICORN_TIMEOUT:-60}
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --limit-request-line 0 --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
 }
 
 create_db() {


### PR DESCRIPTION
# Context
I face this error when I reload the page on some dashboard.
![image](https://user-images.githubusercontent.com/1732016/222311354-366cb4a1-1850-40ce-a9f7-8da8cece9bc4.png)

URL: https://clients.data.ovice.io/dashboards/210-nano-opt-media-data_dashboard

# Overview
* Disable the URL length restriction.

# Areas to focus on
* Once I access the dashboard, parameters for all variables are added to the URL, so if I reload the page then, the URL length exceeds 4096 charactors.
* Related Stackoverflow: https://stackoverflow.com/questions/66688329/request-line-is-too-large-8192-4094
* After merging this PR, I'll build a new docker image in my local and upload it to ECR and use it on k8s cluster.